### PR TITLE
Automatizace pull requestů pomocí Github Actions

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,14 @@
+# Turn on automatic reviewer choosing and assignment
+addReviewers: true
+
+# Automatic assign pull request to its author
+addAssignees: author
+
+# Set of available reviewers
+reviewers:
+  - ceskyDJ
+  - omnitex
+  - TenebrisCZ
+
+# Limit of assigned reviewers
+numberOfReviewers: 1

--- a/.github/workflows/github-pr-automation.yml
+++ b/.github/workflows/github-pr-automation.yml
@@ -1,0 +1,37 @@
+name: 'Automation | Pull request'
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  # Assign pull request to its author and choose and set reviewer
+  auto-assign-author-and-reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.0
+
+  # Copy properties from linked issue from pull request description
+  # (if at least one issue is linked). Properties are labels
+  # and milestones
+  copy-properties-from-issue:
+    if: ${{ github.event.action == 'opened' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ceskyDJ/pr-set-issue-properties@v1.2.2
+        with:
+          way: 'body'
+          issues-close: false
+
+  # Add pull request shortcut to project column
+  # It automatically steps forward to next columns,
+  # so we can see its progress from one place
+  add-to-project:
+    if: ${{ github.event.action == 'opened' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: IFJ & IAL projekt
+          column: In progress
+          repo-token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}


### PR DESCRIPTION
Pomocí Github Actions jsem vytvořil pár automatizací pro pull requesty. Jedná se především o tyto úkony:
- automatické přiřazení pull requestu autorovi,
- výběr a nastavení člověka, který provede revizi,
- zkopírování dalších vlastností z nalinkovaného issue (hodí se pro lepší orientaci v projektu).

Od této doby platí následující:
- jediné, co je nutné v pull requestu uvést, je titulek a popis změn (ostatní se doplní automaticky),
- pull requesty musí obsahovat odkaz na issue (úkol), pokud se na nějaký úkol váže (což je v naprosté většině).

Příklad odkazu (v jazyce Markdown):
```md
Související úkol:
- issue #n
```
Místo `issue` je možné použít i `task`. V případě, že má být úkol po provedení úspěšného začlenění daného pull requestu do větve `main`, mohou být použity i [direktivy Githubu](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (`close`, `fix`, `resolve`, ...).

Chtěl bych poprosit @omnitex, aby tyto informace ve stručnosti doplnil do souboru GIT_RULES.md (#7).