### PR TITLE
Druhý pokus o začlenění opravy nefunkčních Github Actions

### DIFF
--- a/.github/workflows/github-pr-automation.yml
+++ b/.github/workflows/github-pr-automation.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: kentaro-m/auto-assign-action@v1.2.0
+        with:
+          repo-token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
 
   # Copy properties from linked issue from pull request description
   # (if at least one issue is linked). Properties are labels
@@ -22,6 +24,7 @@ jobs:
         with:
           way: 'body'
           issues-close: false
+          token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
 
   # Add pull request shortcut to project column
   # It automatically steps forward to next columns,


### PR DESCRIPTION
Je zajímavé, že mi to jinde fungovalo... No, každopádně chyběly tokeny (ten od Githubu bude asi jen na veřejná repa).

EDIT: Takže už podruhé (původně zkoušeno #14, ale zapomněl jsem zadat provázání s úkolem, takže jsem to nemohl úplně otestovat. Tak snad to bude fungovat.

Související úkoly:
- close #13 