### PR TITLE
Struktura tokenu

### DIFF
--- a/src/token.h
+++ b/src/token.h
@@ -1,0 +1,46 @@
+/**
+ * @file token.h
+ * Token structure.
+ *
+ * IFJ and IAL project (IFJ21 compiler)
+ * Team: 128 (variant II)
+ *
+ * @author Martin Havlík (xhavli56)
+ * @author Michal Šmahel (xsmahe01)
+ */
+
+#ifndef _TOKEN_H_
+#define _TOKEN_H_
+
+enum token_type {
+    // Symbols
+    IDENTIFIER, KEYWORD,
+    // Literals
+    INTEGER, NUMBER, STRING,
+    // Assignment operators
+    ASSIGNMENT,
+    // Math operators
+    ADDITION, SUBTRACTION, MULTIPLICATION, DIVISION, INT_DIVISION,
+    // String operators
+    CONCAT, STRLEN,
+    // Conditional operators
+    LT, GT, LEQ, GEQ, EQ, NEQ,
+    // Special operators
+    TYPE_SPEC, COMMA,
+    // Other
+    LEFT_PAR, RIGHT_PAR
+};
+
+typedef struct token {
+    enum token_type type;
+    union {
+        int integer;
+        double number;
+        char *string;
+        identifier_t *identifier;
+        keyword_t *keyword;
+    };
+} token_t;
+
+#endif
+


### PR DESCRIPTION
Potřeba vyřešit
- [x] budou mít jednotlivá klíčová slova své unikátní typy tokenu, aby syntaktický analyzátor jen z typu tokenu poznal oč jde? šlo by to tak, že `KEYWORD_<something>` by začínaly na určité hodnotě (mocnina 2) a vymaskováním by se dal získat bit "tohle je/není" klíčové slovo a pokud ano, tak zjistit přesně které, nějak. Moc práce při rozlišování typu tokenu? Budeme strcmp dvakrát? Jak se to dá jinak vyřešit?
- [x] v unii ukazatel do tabulky symbolů můžeme nechat `void *` a při dosazování přetypovávat nebo počkat až to bude jasné, na co to ukazuje a pak to tady změnit? Nebo nechat jen jeden `void *` a ten bude sloužit jak pro ukazatel do tabulky symbolů tak pro ukazatel do tabulky řetězců (nikam jinam ne?)

- closes #19 