### PR TITLE
Přidání dokumentačního komentáře do souboru main.c

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1,3 +1,12 @@
+/**
+ * @file main.c
+ * Main control source file.
+ *
+ * IFJ and IAL project (IFJ21 compiler)
+ * Team: 128 (variant II)
+ *
+ * @author Michal Šmahel (xsmahe01)
+ */
 #include <stdio.h>
 
 int main() {


### PR DESCRIPTION
Pravidelně neprocházejí základní testy ze dvou důvodů - chybí dokumentační komentář v souboru `main.c` a chybí implementace tabulky symbolů. První problém je poměrně jednoduše řešitelný, takže proč ho rovnou nevyřešit, že? Až se přidá implementace tabulky symbolů, budou testy krásně procházet.