### PR TITLE
Unit testy nejsou označené jako chybné, když dojde k chybě při překladu

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run Make rule for creating and running unit tests
-        run: cd src; make test; ../test/unit/get-results.sh
+        run: cd src; make test && ../test/unit/get-results.sh
         env:
           EXTRA_CFLAGS: -Werror


### PR DESCRIPTION
Už si přesně nepamatuji, kde se to stalo, tuším, že v #58, ale na tom příliš nesejde. Jde o to, že bylo možné, že nějaká sada unit testů selhala při překladu a tím pádem ani nedošlo k jejich spuštění. Ve výsledku tedy byly prohlášeny za úspěšné.

Tato malá úprava by tomu měla zamezit. Make v případě, že nějaké pravidlo selže, vrátí nenulový návratový kód, takže se pak ani nespustí skript pro otestování výsledků testů, ale rovnou výraz selže a Github Actions by to měly vyhodnotit jako neprojité unit testy.