### PR TITLE
`string_clear()` + pár úprav

### DIFF
--- a/src/string_factory.c
+++ b/src/string_factory.c
@@ -101,3 +101,12 @@ char *string_expose(string_t *str)
     return str->content;
 }
 
+void string_clear(string_t *str)
+{
+    assert(str);
+
+    memset(str->content, '\0', str->len);
+
+    str->len = 0;
+}
+

--- a/src/string_factory.h
+++ b/src/string_factory.h
@@ -102,6 +102,15 @@ char *string_export(string_t *str);
  */
 char *string_expose(string_t *str);
 
+/**
+ * Clears (zeroes out) ADT string for safe repeated use.
+ *
+ * @param str String which to clear.
+ *
+ * @pre str != NULL
+ */
+void string_clear(string_t *str);
+
 struct string {
     size_t len;
     size_t max_len;

--- a/test/unit/test_string_factory.c
+++ b/test/unit/test_string_factory.c
@@ -231,3 +231,14 @@ void test_string_expose()
     TEST_ASSERT_EQUAL_STRING(exposed, "hello");
 }
 
+void test_string_clear()
+{
+    string_t *str = string_create();
+    append_to_string(str, "hello");
+
+    string_clear(str);
+
+    TEST_ASSERT_EQUAL_INT(0, str->len);
+    TEST_ASSERT_EQUAL_STRING("", str->content);
+}
+


### PR DESCRIPTION
Pro potřeby scanneru viz #68, aby se `string_t` nemusel při každém volání `get_token()` alokovat a dealokovat, tak se pouze vyčistí.