### PR TITLE
Chybná cesta k obj souborům zkompilovaných unit testů

### DIFF
--- a/test/unit/get-dependency-list.sh
+++ b/test/unit/get-dependency-list.sh
@@ -51,7 +51,8 @@ function fix_paths() {
   # 3. paths of unit test sources to paths of corresponding obj files (after compilation)
   sed -E 's|([a-zA-Z0-9_]+\.h)|'"$OBJ_P"'/\1|g' \
     | sed -E 's|([a-zA-Z0-9_]+)(\.o)|'"$OBJ_P"'/\1_final\2|g' \
-    | sed -E 's|'"$OBJ_P"'/([a-zA-Z0-9_]+\.c)|'"$OBJ_P"'/\1|g'
+    | sed -E 's|'"$OBJ_P"'/([a-zA-Z0-9_]+\.c)|'"$OBJ_P"'/\1|g' \
+    | sed 's|'"$TEST_P"'|'"$OBJ_P"'|'
 }
 
 # Set correct file extensions


### PR DESCRIPTION
Ono v zásadě vše funguje, jen vzniká bordel v `test/unit`, kde se shromažďují obj soubory zkompilovaných unit testů. Oprava je poměrně jednoduchá, jen se doplní nahrazení cesty na správnou (což jsem měl udělat už v #72). Omlouvám se za pochybení.