### PR TITLE
Používání GCC verze 10

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -19,6 +19,15 @@ jobs:
           host: github.com
           private-key: ${{ secrets.SSH_PRIV_KEY }}
 
+      - name: Set up GCC
+        uses: egor-tensin/setup-gcc@v1
+        with:
+          version: 10
+          platform: x64
+
+      - name: We need gcc-10.2 but we have gcc-10 only...
+        run: sudo ln -s /usr/bin/gcc-10 /usr/local/bin/gcc-10.2
+
       - name: Install packages for LaTeX (and BibTeX) compilation
         run: sudo apt install -y texlive texlive-plain-generic texlive-latex-extra texlive-lang-czechslovak texlive-lang-greek texlive-font-utils texlive-bibtex-extra
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,6 +9,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up GCC
+        uses: egor-tensin/setup-gcc@v1
+        with:
+          version: 10
+          platform: x64
+
+      - name: We need gcc-10.2 but we have gcc-10 only...
+        run: sudo ln -s /usr/bin/gcc-10 /usr/local/bin/gcc-10.2
+
       - name: Run Make rule for creating and running unit tests
         run: cd src; make test && ../test/unit/get-results.sh
         env:

--- a/src/Makefile
+++ b/src/Makefile
@@ -45,7 +45,7 @@ PASSED_TESTS = `grep -qs PASS $(RES_P)/*.txt && grep PASS $(RES_P)/*.txt | sed -
 FAILED_TESTS = `grep -qs FAIL[^E] $(RES_P)/*.txt && grep FAIL[^E] $(RES_P)/*.txt | sed -E 's|$(RES_P)/[a-zA-Z_]+\.txt:../||g' || echo "There are no failed tests"`
 
 # Compiler configs
-CC=gcc
+CC=gcc-10.2
 LINKER=ld
 CFLAGS=-std=c11 -g -pedantic -Wall -Wextra $$EXTRA_CFLAGS
 

--- a/src/Makefile.patch
+++ b/src/Makefile.patch
@@ -1,5 +1,5 @@
---- Makefile.std	2021-11-19 15:59:00.948144130 +0100
-+++ Makefile	2021-11-19 16:06:57.481855321 +0100
+--- Makefile.std	2021-11-23 21:05:43.300288174 +0100
++++ Makefile	2021-11-23 21:06:07.456519626 +0100
 @@ -10,44 +10,24 @@
  
  # Usage:
@@ -42,7 +42,7 @@
 +OBJ_P=.
  
  # Compiler configs
- CC=gcc
+ CC=gcc-10.2
 -LINKER=ld
 -CFLAGS=-std=c11 -g -pedantic -Wall -Wextra $$EXTRA_CFLAGS
 +CFLAGS=-std=c11 -g -pedantic -Wall -Wextra


### PR DESCRIPTION
Aby bylo jistější, že překlad na Merlinovi dopadne dobře, bude se nyní vyžadovat GCC ve verzi 10 všude, kde se bude provádět kompilace (včetně Github Actions).

Související úkoly:
- closes #69 