### PR TITLE
Vyčlenění `identifier_t` a souvisejících enumů do svého `.h`

### DIFF
--- a/src/identifier.h
+++ b/src/identifier.h
@@ -1,0 +1,45 @@
+/**
+ * @file identifier.h
+ * Identifier structure.
+ *
+ * IFJ and IAL project (IFJ21 compiler)
+ * Team: 128 (variant II)
+ *
+ * @author Martin Havlík (xhavli56)
+ */
+
+#ifndef _IDENTIFIER_H_
+#define _IDENTIFIER_H_
+
+enum variable_type {
+    VAR_INTEGER='i', VAR_NUMBER='n', VAR_STRING='s'
+};
+enum identifier_type {
+    VARIABLE=1, FUNCTION
+};
+
+/**
+ * Structure representing an identifier,
+ * an element of symtable.
+ */
+typedef struct identifier {
+    char *name;
+    unsigned long line;
+    unsigned long character;
+    enum identifier_type type;
+    union {
+        struct variable {
+            char type;
+            int init;
+            int used;
+        } var;
+        struct function {
+            int defined;
+            char *param; // "" -> takes void
+            char *retval; // "" -> returns void
+        } fun;
+    };
+} identifier_t;
+
+#endif
+

--- a/src/symtable.h
+++ b/src/symtable.h
@@ -14,43 +14,14 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#define SYMTABLE_BUCKETS 23
+#include "identifier.h"
 
-enum variable_type {
-    VAR_INTEGER='i', VAR_NUMBER='n', VAR_STRING='s'
-};
-enum identifier_type {
-    VARIABLE=1, FUNCTION
-};
+#define SYMTABLE_BUCKETS 23
 
 /**
  * Symbol table abstract data type.
  */
 typedef struct symtable symtable_t;
-
-
-/**
- * Structure representing an identifier,
- * an element of symtable.
- */
-typedef struct identifier {
-    char *name;
-    unsigned long line;
-    unsigned long character;
-    enum identifier_type type;
-    union {
-        struct variable {
-            char type;
-            int init;
-            int used;
-        } var;
-        struct function {
-            int defined;
-            char *param; // "" -> takes void
-            char *retval; // "" -> returns void
-        } fun;
-    };
-} identifier_t;
 
 typedef struct symtable_item {
     identifier_t identifier;


### PR DESCRIPTION
Aby když potřebuju fakt jen `identifier_t` tak nebylo nutné to brát spolu s věcmi ze `symtable`.