### PR TITLE
Variable type `VAR_TYPELESS`

### DIFF
--- a/src/identifier.h
+++ b/src/identifier.h
@@ -12,7 +12,7 @@
 #define _IDENTIFIER_H_
 
 enum variable_type {
-    VAR_INTEGER='i', VAR_NUMBER='n', VAR_STRING='s', VAR_BOOL='b'
+    VAR_INTEGER='i', VAR_NUMBER='n', VAR_STRING='s', VAR_BOOL='b', VAR_TYPELESS='t'
 };
 enum identifier_type {
     VARIABLE=1, FUNCTION


### PR DESCRIPTION
Toto bude možná potřeba rozmyslet lépe. Co když bude složitý výraz a v něm bude nedefinovaná proměnná? Přijdeme na to?

- [x] Teď nevím ale on `expr_parser` nekontroluje jestli ta proměnná co najde v symtable má už typ, co? Protože tam se chceme hned zarazit, podle mě, jinak se to v tom výrazu ztratí a on celý nabyde validního typu, ale uvnitř bude nedefinovaná proměnná